### PR TITLE
bug 681842 - rename events to have either 'owa', 'owa.mediation' or 'fxshare' prefixes

### DIFF
--- a/data/ui/scripts/mediator.js
+++ b/data/ui/scripts/mediator.js
@@ -46,7 +46,7 @@ define(function () {
           //Useful for sending previews in email.
           var preview = options.previews && options.previews[0];
           if (preview && preview.http_url && !preview.base64) {
-            emit('generateBase64Preview', preview.http_url);
+            emit('fxshare.generateBase64Preview', preview.http_url);
           }
         },
         
@@ -67,24 +67,20 @@ define(function () {
         },
 
         sizeToContent: function() {
-            emit('sizeToContent');
-        },
-        
-        reconfigure: function() {
-            emit('reconfigure');
+            emit('owa.mediation.sizeToContent');
         },
         
         updateChromeStatus: function(status) {
-            emit('updateStatus', status);
+            emit('fxshare.updateStatus', status);
         },
 
         // This is the 'success' notification defined by OWA.
         result: function(resultInfo) {
-            emit('result', resultInfo);
+            emit('owa.success', resultInfo);
         },
         
         error: function(appid) {
-            emit('error', {app:appid, result: "error"});
+            emit('owa.failure', {app:appid, result: "error"});
         }
     }
     return m;

--- a/lib/panel.js
+++ b/lib/panel.js
@@ -163,8 +163,8 @@ SharePanel.prototype = {
 
   attachHandlers: function() {
     MediatorPanel.prototype.attachHandlers.apply(this);
-    this.panel.port.on("updateStatus", this.onUpdateStatus.bind(this));
-    this.panel.port.on("generateBase64Preview", this.onGenerateBase64Preview.bind(this));
+    this.panel.port.on("fxshare.updateStatus", this.onUpdateStatus.bind(this));
+    this.panel.port.on("fxshare.generateBase64Preview", this.onGenerateBase64Preview.bind(this));
   },
   /* END OWA INTERFACE */
 
@@ -187,7 +187,7 @@ SharePanel.prototype = {
    * The domain, username and userid taken together form a unique identifier
    * for which account on which service was used to do the share.
    */
-  onResult: function(data) {
+  onOWASuccess: function(data) {
     let url = data.link;
     let title = data.title;
     this.onUpdateStatus({
@@ -209,7 +209,7 @@ SharePanel.prototype = {
     }
     // and we want this message to also be processed by OWA itself, which will
     // close the panel.
-    MediatorPanel.prototype.onResult.apply(this, arguments);
+    MediatorPanel.prototype.onOWASuccess.apply(this, arguments);
   },
 
   /**

--- a/tests/app_helpers.js
+++ b/tests/app_helpers.js
@@ -101,7 +101,7 @@ exports.getSharePanelWithApp = function(test, args, cb) {
       });
 
       let panel = getSharePanel();
-      panel.panel.port.once("ready", function() {
+      panel.panel.port.once("owa.mediation.ready", function() {
         // The mediator reported it is ready - now find the contentWindow for the mediator.
         // We can't get it via the panel, so we use our knowledge of the panel
         // implementation - it appended a XUL panel to the mainPopupSet.

--- a/tests/test-bookmark-page.js
+++ b/tests/test-bookmark-page.js
@@ -40,7 +40,7 @@ exports.testBookmarkPage = function(test) {
     }
     Services.prefs.setBoolPref("services.share.bookmarking", true);
     try {
-      sharePanel.onResult(shareMessage);
+      sharePanel.onOWASuccess(shareMessage);
     } finally {
       if (typeof oldPrefVal !== 'undefined') {
         Services.prefs.setBoolPref("services.share.bookmarking", oldPrefVal);


### PR DESCRIPTION
rename events to have either 'owa', 'owa.mediation' or 'fxshare' prefixes
