### PR TITLE
Bug #682211 - html selection boxes clipped by panel (share type and autocomplete)

### DIFF
--- a/data/ui/scripts/AutoComplete.js
+++ b/data/ui/scripts/AutoComplete.js
@@ -49,7 +49,7 @@ function ($,        object,         fn,         module,   dispatch,
       this.attachedWidget = false;
       this.acOptions = [];
       this.owasvc = owasvc;
-      this.orient = owasvc.parameters.features.subject ? 'below' : 'above';
+      this.orient = owasvc.parameters.features.subjectLabel ? 'below' : 'above';
 
       // XXX - still relevant?
       dispatch.sub('optionsChanged', fn.bind(this, function (data) {

--- a/data/ui/share/scripts/widgets/AccountPanel.html
+++ b/data/ui/share/scripts/widgets/AccountPanel.html
@@ -1,5 +1,5 @@
-<div class="{svc.type} {className}">
-  <form name="{svc.type}Send" class="hbox messageForm" action="#">
+<div class="{svc.auth.name} {className}">
+  <form name="{svc.auth.name}Send" class="hbox messageForm" action="#">
     <div class="user inactive col">
       <input type="hidden" name="userid" value="{profile.userid}" />
       <input type="hidden" name="username" value="{profile.username}" />
@@ -24,7 +24,7 @@
         <input name="subject" placeholder="subject" type="text" value="{options.subject}" autocomplete="off"/>
       {]}
       <textarea class="message compose" placeholder="Type your message here, and we'll attach the link when you send." name="message">{options.message}</textarea>
-      
+
       <div id="pageInfo">
         <div class="hbox">
             {svc.features.picture [}

--- a/data/ui/share/style.css
+++ b/data/ui/share/style.css
@@ -676,6 +676,10 @@ span.icon.twitter {
     facebook styles
 */
 
+.facebook.widgets-AccountPanel .shareTypeSection .Select.open ul {
+  top: -40px;
+}
+
 .facebook .facebookActions {
   margin: 0 0 10px 0;
   width: 100%;


### PR DESCRIPTION
Repositions the custom HTML simulated select for facebook's shareType choices so that all options are visible.  Also updates AutoComplete's use of owasvc.parameters.features to use the right property, subjectLabel, so that if/when gmail is supported, the to: autocomplete will be visible.
