### PR TITLE
Fixes #688848, change add-on name/id so it does not conflict with old F1 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "ffshare",
-    "id": "ffshare@mozilla.org",
+    "name": "fx-share-addon",
+    "id": "fx-share-addon@mozilla.org",
     "description": "Share things",
     "author": "Mozilla",
     "version": "0.001",


### PR DESCRIPTION
Fixes #688848, change add-on name/id so it does not conflict with old F1 add-on.
